### PR TITLE
fix: Switch Pro Controller make work

### DIFF
--- a/Assets/Test3/GyroRotate.cs
+++ b/Assets/Test3/GyroRotate.cs
@@ -8,17 +8,23 @@ public class GyroRotate : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+
+        SwitchControllerHID.current.ReadUserIMUCalibrationData();
+
     }
 
     // Update is called once per frame
     void Update()
     {
-        if (SwitchControllerHID.current.buttonSouth.wasPressedThisFrame)
+        if (SwitchControllerHID.current.buttonSouth.wasReleasedThisFrame)
         {
-            // SwitchControllerHID.current.ReadIMUCalibrationData();
-            SwitchControllerHID.current.SetIMUEnabled(true);
+            SwitchControllerHID.current.ReadUserIMUCalibrationData();
+            // SwitchControllerHID.current.SetIMUEnabled(true);
         }
-        transform.eulerAngles = SwitchControllerHID.current.orientation.ReadValue() * 0.1f;
+        if (SwitchControllerHID.current.buttonEast.wasReleasedThisFrame)
+        {
+            SwitchControllerHID.current.ResetYaw();
+        }
+        transform.localRotation = SwitchControllerHID.current.deviceRotation.ReadValue();
     }
 }

--- a/Packages/com.canopteks.switchcontrollerinput/Editor/EditorWindow/DeviceDebugWindow.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Editor/EditorWindow/DeviceDebugWindow.cs
@@ -152,6 +152,32 @@ namespace SwitchControllerInput.Editor
                         controller.SetIMUEnabled(false);
                     }
                     EditorGUILayout.EndHorizontal();
+
+                    EditorGUILayout.Separator();
+                    GUILayout.Label("LEDs: ", EditorStyles.boldLabel);
+                    EditorGUILayout.BeginHorizontal();
+                    if (GUILayout.Button("P1"))
+                    {
+                        controller.SetLEDs(p1: LEDStatusEnum.On);
+                    }
+                    if (GUILayout.Button("P2"))
+                    {
+                        controller.SetLEDs(p2: LEDStatusEnum.On);
+                    }
+                    if (GUILayout.Button("P3"))
+                    {
+                        controller.SetLEDs(p3: LEDStatusEnum.On);
+                    }
+                    if (GUILayout.Button("P4"))
+                    {
+                        controller.SetLEDs(p4: LEDStatusEnum.On);
+                    }
+                    if (GUILayout.Button("Off"))
+                    {
+                        controller.SetLEDs();
+                    }
+                    EditorGUILayout.EndHorizontal();
+
                     if (GUILayout.Button("Read Factory Calibration"))
                     {
                         controller.ReadFactoryIMUCalibrationData();

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/Commands/SwitchControllerSubcommand.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/Commands/SwitchControllerSubcommand.cs
@@ -63,12 +63,12 @@ namespace UnityEngine.InputSystem.Switch
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.GetOnlyControllerState;
     }
-    
+
     public class SwitchControllerRequestInfoSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.RequestDeviceInfo;
     }
-    
+
     public class SwitchControllerBluetoothManualPairingSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.BluetoothManualPairing;
@@ -76,7 +76,7 @@ namespace UnityEngine.InputSystem.Switch
         public byte ValueByte = 0x01;
         protected override byte[] GetArguments() => new byte[0x1] { ValueByte };
     }
-    
+
     public class SwitchControllerSetImuEnabledSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.EnableDisableIMU;
@@ -84,7 +84,7 @@ namespace UnityEngine.InputSystem.Switch
         public bool Enabled = true;
         protected override byte[] GetArguments() => new byte[0x1] { (byte)(Enabled ? 0x01 : 0x00) };
     }
-    
+
     public class SwitchControllerSetVibrationEnabledSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.EnableDisableVibration;
@@ -92,7 +92,7 @@ namespace UnityEngine.InputSystem.Switch
         public bool Enabled = true;
         protected override byte[] GetArguments() => new byte[0x1] { (byte)(Enabled ? 0x01 : 0x00) };
     }
-    
+
     public class SwitchControllerReadSPIFlashSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.SPIFlashRead;
@@ -117,7 +117,33 @@ namespace UnityEngine.InputSystem.Switch
             Length = withLength;
         }
     }
-    
+
+    public class SwitchControllerWriteSPIFlashSubcommand : SwitchControllerBaseSubcommand
+    {
+        public override byte SubcommandID => (byte)SubcommandIDEnum.SPIFlashWrite;
+
+        public uint Address = 0x0;
+        public byte Length = 0x0;
+        public byte[] Data;
+
+        protected override byte[] GetArguments()
+        {
+            var addrAsBytes = BitConverter.GetBytes(Address);
+            byte[] output = new byte[5 + Length];
+            Array.Copy(addrAsBytes, output, 4);
+            output[4] = Length;
+            Array.Copy(Data, 0, output, 5, Length);
+            return output;
+        }
+
+        public SwitchControllerWriteSPIFlashSubcommand(uint atAddress, byte[] data)
+        {
+            Address = atAddress;
+            Length = (byte)data.Length;
+            Data = data;
+        }
+    }
+
     public class SwitchControllerSetLEDSubcommand : SwitchControllerBaseSubcommand
     {
         public override byte SubcommandID => (byte)SubcommandIDEnum.SetPlayerLights;
@@ -147,10 +173,10 @@ namespace UnityEngine.InputSystem.Switch
 
     public class SwitchControllerInputModeSubcommand : SwitchControllerBaseSubcommand
     {
-        public override byte SubcommandID => (byte) SubcommandIDEnum.SetInputReportMode;
+        public override byte SubcommandID => (byte)SubcommandIDEnum.SetInputReportMode;
         public InputModeEnum InputMode = InputModeEnum.Standard;
 
-        protected override byte[] GetArguments() => new byte[1] {(byte) InputMode};
+        protected override byte[] GetArguments() => new byte[1] { (byte)InputMode };
 
         public SwitchControllerInputModeSubcommand(InputModeEnum mode)
         {

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerFullInputReport.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerFullInputReport.cs
@@ -138,35 +138,25 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
 
         public Vector3 CalibratedAcceleration(ref SwitchControllerHID.IMUCalibrationData calib)
         {
-            // var coeffs = new Vector3()
-            // {
-            //     x = (float)(1.0f / (float)(0x4000 - uint16_to_int16(cal_acc_origin))) * 4.0f
-            // };
+            if (calib.accelSensitivity.x == 0)
+                return UncalibratedAcceleration;
 
-            var output = new Vector3();
-            return output;
+            float accel_x = (accelX - (short)calib.accelBase.x) * calib.accelCoeff.x;
+            float accel_y = (accelY - (short)calib.accelBase.y) * calib.accelCoeff.y;
+            float accel_z = (accelZ - (short)calib.accelBase.z) * calib.accelCoeff.z;
+
+            return new Vector3(accel_x, accel_y, accel_z);
         }
 
         public Vector3 CalibratedGyro(ref SwitchControllerHID.IMUCalibrationData calib)
         {
-            var offset = calib.gyroBase.ToVector3Int16();
-            var coeff = calib.gyroSensitivity;
+            if (calib.gyroSensitivity.x == 0)
+                return UncalibratedGyro;
 
-            float gyro_x = 0;
-            float gyro_y = 0;
-            float gyro_z = 0;
-            
-            // gyro X
-            var gyro_cal_coeff_x = (float)(816.0f / (float)(coeff.x - offset.x));
-            gyro_x = (gyro1 - offset.x) * gyro_cal_coeff_x;
+            float gyro_x = (gyro1 - (short)calib.gyroBase.x) * calib.gyroCoeff.x;
+            float gyro_y = (gyro2 - (short)calib.gyroBase.y) * calib.gyroCoeff.y;
+            float gyro_z = (gyro3 - (short)calib.gyroBase.z) * calib.gyroCoeff.z;
 
-            // gyro Y
-            var gyro_cal_coeff_y = (float)(816.0f / (float)(coeff.y - offset.y));
-            gyro_y = (gyro2 - offset.y) * gyro_cal_coeff_y;
-
-            // gyro Z
-            var gyro_cal_coeff_z = (float)(816.0f / (float)(coeff.z - offset.z));
-            gyro_z = (gyro3 - offset.z) * gyro_cal_coeff_z;
 
             return new Vector3(gyro_x, gyro_y, gyro_z);
         }

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerFullInputReport.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerFullInputReport.cs
@@ -43,7 +43,7 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public SwitchControllerVirtualInputState ToHIDInputReport(ref SwitchControllerHID.CalibrationData calibData, SpecificControllerTypeEnum controllerType, Vector3 currentOrientation)
+        public SwitchControllerVirtualInputState ToHIDInputReport(ref SwitchControllerHID.CalibrationData calibData, SpecificControllerTypeEnum controllerType)
         {
             var leftStickVec = Vector2.zero;
             var rightStickVec = Vector2.zero;
@@ -84,14 +84,19 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
             }
 
             // Debug.Log($"Creating input stuff: right stick is {rightStickVec}");
+            Vector3 uncalibratedAccel = imuData0ms.UncalibratedAcceleration;
+            Vector3 uncalibratedGyro = imuData0ms.UncalibratedGyro;
+            Vector3 calibratedAccel = imuData0ms.CalibratedAcceleration(ref calibData.imuCalibData);
+            Vector3 calibratedGyro = imuData0ms.CalibratedGyro(ref calibData.imuCalibData);
+
             var state = new SwitchControllerVirtualInputState
             {
                 leftStick = leftStickVec,
                 rightStick = rightStickVec,
-                // TODO: Calibrate these bad boys
-                acceleration = imuData0ms.UncalibratedAcceleration,
-                orientation = currentOrientation + imuData0ms.UncalibratedGyro,
-                angularVelocity = imuData0ms.UncalibratedGyro
+                uncalibratedAcceleration = uncalibratedAccel,
+                uncalibratedAngularVelocity = uncalibratedGyro,
+                acceleration = calibratedAccel,
+                angularVelocity = calibratedGyro
             };
 
             state.Set(SwitchControllerVirtualInputState.Button.Y, (rightButtons & 0x01) != 0);

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
@@ -8,19 +8,25 @@ using UnityEngine.InputSystem.Utilities;
 using System.Runtime.InteropServices;
 using Unity.Collections.LowLevel.Unsafe;
 using System.Text;
+using System.Collections.Generic;
 
 namespace UnityEngine.InputSystem.Switch
 {
     [InputControlLayout(stateType = typeof(SwitchControllerVirtualInputState))]
-    #if UNITY_EDITOR
+#if UNITY_EDITOR
     [InitializeOnLoad]
-    #endif
+#endif
     public abstract class SwitchControllerHID : InputDevice, IInputStateCallbackReceiver, IEventPreProcessor
     {
         #region Accelerometer/gyroscope controls
         public Vector3Control angularVelocity { get; private set; }
         public Vector3Control orientation { get; private set; }
         public Vector3Control acceleration { get; private set; }
+        public QuaternionControl deviceRotation { get; private set; }
+
+        // Uncalibrated values for debugging
+        public Vector3Control uncalibratedAngularVelocity { get; private set; }
+        public Vector3Control uncalibratedAcceleration { get; private set; }
         #endregion
 
         #region Button controls
@@ -41,7 +47,7 @@ namespace UnityEngine.InputSystem.Switch
         public ButtonControl select { get; private set; }
         public ButtonControl leftShoulderMini { get; private set; }
         public ButtonControl rightShoulderMini { get; private set; }
-        
+
         public StickControl leftStick { get; private set; }
         public StickControl rightStick { get; private set; }
         #endregion
@@ -61,7 +67,8 @@ namespace UnityEngine.InputSystem.Switch
             public IMUCalibrationData imuCalibData;
         }
 
-        public CalibrationData calibrationData = new CalibrationData() {
+        public CalibrationData calibrationData = new CalibrationData()
+        {
             lStickCalibData = new StickCalibrationData()
             {
                 xMin = 720,
@@ -80,6 +87,14 @@ namespace UnityEngine.InputSystem.Switch
         #endregion
 
         private Vector3 m_currentOrientation = new Vector3();
+        private double m_lastUpdateTime;
+        private IMUData m_lastIMUData;
+
+        // Madgwick's Algorithm variables
+        public float MadgwickBeta = 0.01f; // Algorithm gain
+        private float q0 = 1.0f, q1 = 0.0f, q2 = 0.0f, q3 = 0.0f; // Quaternion of sensor frame relative to auxiliary frame
+
+        // public float kComplementaryFilterGain = 0.98f; // No longer used
 
         #region Generic data
         public BatteryLevelEnum BatteryLevel { get; protected set; } = BatteryLevelEnum.Empty;
@@ -99,6 +114,7 @@ namespace UnityEngine.InputSystem.Switch
         private bool m_deviceInfoLoaded = false;
         private bool m_colorsLoaded = false;
         private bool m_serialNumberLoaded = false;
+        private bool m_imuCalibrationDataLoaded = false;
 
         // Register the time of last request to retry to fetch them in case of timeout
         private double m_stickCalibrationTimeOfLastRequest;
@@ -112,8 +128,24 @@ namespace UnityEngine.InputSystem.Switch
         private const double timeout = 1.0;
         #endregion
 
+        #region Calibration Process
+        public enum CalibrationState
+        {
+            None,
+            InProgress,
+            Done
+        }
+        public CalibrationState CurrentCalibrationState { get; private set; } = CalibrationState.None;
+        public float CalibrationProgress { get; private set; } = 0f;
+        private double m_calibrationStartTime;
+        private float m_calibrationDuration;
+        private Vector3 m_accumulatedAccel;
+        private Vector3 m_accumulatedGyro;
+        private int m_sampleCount;
+        #endregion
+
         #region Unity InputDevice boilerplate
-        
+
         /// <summary>
         /// The last used/added Joy-Con (R) controller.
         /// </summary>
@@ -149,9 +181,12 @@ namespace UnityEngine.InputSystem.Switch
             angularVelocity = GetChildControl<Vector3Control>("angularVelocity");
             orientation = GetChildControl<Vector3Control>("orientation");
             acceleration = GetChildControl<Vector3Control>("acceleration");
+            deviceRotation = GetChildControl<QuaternionControl>("deviceRotation");
+            uncalibratedAngularVelocity = GetChildControl<Vector3Control>("uncalibratedAngularVelocity");
+            uncalibratedAcceleration = GetChildControl<Vector3Control>("uncalibratedAcceleration");
 
             dpad = GetChildControl<DpadControl>("dpad");
-            
+
             leftShoulder = GetChildControl<ButtonControl>("leftShoulder");
             rightShoulder = GetChildControl<ButtonControl>("rightShoulder");
             leftStickPress = GetChildControl<ButtonControl>("leftStickPress");
@@ -190,6 +225,7 @@ namespace UnityEngine.InputSystem.Switch
             m_infoTimeOfLastRequest = InputRuntime.s_Instance.currentTime;
             m_stickCalibrationTimeOfLastRequest = InputRuntime.s_Instance.currentTime;
             m_serialNumberTimeOfLastRequest = InputRuntime.s_Instance.currentTime;
+            m_lastUpdateTime = InputRuntime.s_Instance.currentTime;
         }
 
         /// <inheritdoc />
@@ -199,10 +235,32 @@ namespace UnityEngine.InputSystem.Switch
             if (current == this)
                 current = null;
         }
-        
+
         /// <inheritdoc />
         public void OnNextUpdate()
         {
+            // Handle calibration process first to ensure it's not blocked by other updates.
+            if (CurrentCalibrationState == CalibrationState.InProgress)
+            {
+                double elapsedTime = InputRuntime.s_Instance.currentTime - m_calibrationStartTime;
+                CalibrationProgress = (float)(elapsedTime / m_calibrationDuration);
+
+                // Accumulate data
+                m_accumulatedAccel += new Vector3(m_lastIMUData.accelX, m_lastIMUData.accelY, m_lastIMUData.accelZ);
+                m_accumulatedGyro += new Vector3(m_lastIMUData.gyro1, m_lastIMUData.gyro2, m_lastIMUData.gyro3);
+                m_sampleCount++;
+
+                if (elapsedTime >= m_calibrationDuration)
+                {
+                    // Finish calibration
+                    Vector3 avgAccel = m_accumulatedAccel / m_sampleCount;
+                    Vector3 avgGyro = m_accumulatedGyro / m_sampleCount;
+                    WriteUserIMUCalibrationData(avgAccel, avgGyro);
+                }
+            }
+
+            // Keep track of time for sensor fusion
+            m_lastUpdateTime = InputRuntime.s_Instance.currentTime;
             if (!m_colorsLoaded)
             {
                 UpdateColors();
@@ -213,12 +271,12 @@ namespace UnityEngine.InputSystem.Switch
                 UpdateDeviceInfo();
                 return;
             }
-            if(!m_stickConfigDataLoaded)
+            if (!m_stickConfigDataLoaded)
             {
                 UpdateStickCalibrationData();
                 return;
             }
-            if(!m_serialNumberLoaded)
+            if (!m_serialNumberLoaded)
             {
                 UpdateSerialNumber();
                 return;
@@ -276,28 +334,23 @@ namespace UnityEngine.InputSystem.Switch
                 ReadSerialNumber();
             }
         }
+
         #endregion
 
         #region Public interactions with the controller (output reports)
         public void Rumble(SwitchControllerRumbleProfile rumbleProfile)
         {
             var c = SwitchControllerCommand.Create(rumbleProfile);
-            long returned = ExecuteCommand(ref c);
-            if (returned < 0)
-            {
+            if (ExecuteCommand(ref c) < 0)
                 Debug.LogError("Rumble command failed");
-            }
         }
 
         public void ReadControllerInfo()
         {
             Debug.Log("Requesting device info...");
             var c = SwitchControllerCommand.Create(subcommand: new SwitchControllerRequestInfoSubcommand());
-            long returned = ExecuteCommand(ref c);
-            if (returned < 0)
-            {
+            if (ExecuteCommand(ref c) < 0)
                 Debug.LogError("Request device info failed");
-            }
         }
 
         public void DoBluetoothPairing()
@@ -315,7 +368,6 @@ namespace UnityEngine.InputSystem.Switch
             var s3 = new SwitchControllerBluetoothManualPairingSubcommand();
             s3.ValueByte = 0x03;
             var c3 = SwitchControllerCommand.Create(subcommand: s3);
-
             if (ExecuteCommand(ref c1) < 0)
                 Debug.LogError("Step 1 of bluetooth pairing failed");
 
@@ -332,6 +384,7 @@ namespace UnityEngine.InputSystem.Switch
             var c = SwitchControllerCommand.Create(subcommand: new SwitchControllerInputModeSubcommand(mode));
             if (ExecuteCommand(ref c) < 0)
                 Debug.LogError($"Set report mode to {mode} failed");
+            m_IMUConfigDataLoaded = (mode == InputModeEnum.Standard);
         }
 
         public void SetIMUEnabled(bool active)
@@ -361,20 +414,26 @@ namespace UnityEngine.InputSystem.Switch
             LEDStatusEnum p4 = LEDStatusEnum.Off)
         {
             var c = SwitchControllerCommand.Create(subcommand: new SwitchControllerSetLEDSubcommand(p1, p2, p3, p4));
-
             if (ExecuteCommand(ref c) < 0)
                 Debug.LogError("Set LEDs failed");
-            else 
-                Debug.Log("LEDs set with success for " + name);
         }
 
-        public void ReadIMUCalibrationData()
+        public void ReadFactoryIMUCalibrationData()
         {
             var readSubcommand = new SwitchControllerReadSPIFlashSubcommand(atAddress: (uint)SPIFlashReadAddressEnum.FactoryIMUCalibration, withLength: 0x18);
-            Debug.Log($"Requesting IMU calibration info...");
+            Debug.Log($"Requesting Factory IMU calibration info...");
             var c = SwitchControllerCommand.Create(subcommand: readSubcommand);
             if (ExecuteCommand(ref c) < 0)
-                Debug.LogError("Read IMU calibration info failed");
+                Debug.LogError("Read Factory IMU calibration info failed");
+        }
+
+        public void ReadUserIMUCalibrationData()
+        {
+            var readSubcommand = new SwitchControllerReadSPIFlashSubcommand(atAddress: (uint)SPIFlashReadAddressEnum.UserIMUCalibration, withLength: 0x1A);
+            Debug.Log($"Requesting User IMU calibration info...");
+            var c = SwitchControllerCommand.Create(subcommand: readSubcommand);
+            if (ExecuteCommand(ref c) < 0)
+                Debug.LogError("Read User IMU calibration info failed");
         }
 
         public void ReadColors()
@@ -395,13 +454,130 @@ namespace UnityEngine.InputSystem.Switch
                 Debug.LogError("Read factory stick calibration info failed");
         }
 
-        public void ReadSerialNumber() 
+        public void ReadSerialNumber()
         {
             var readSubcommand = new SwitchControllerReadSPIFlashSubcommand(atAddress: (uint)SPIFlashReadAddressEnum.SerialNumber, withLength: 0x10);
             Debug.Log($"Requesting device serial number...");
             var c = SwitchControllerCommand.Create(subcommand: readSubcommand);
             if (ExecuteCommand(ref c) < 0)
                 Debug.LogError("Read device serial number failed");
+        }
+
+        public void StartIMUCalibration(float duration = 5.0f)
+        {
+            if (CurrentCalibrationState == CalibrationState.InProgress)
+            {
+                Debug.LogWarning("Calibration is already in progress.");
+                return;
+            }
+            Debug.Log($"Starting IMU calibration for {duration} seconds. Keep the controller stable.");
+            CurrentCalibrationState = CalibrationState.InProgress;
+            m_calibrationStartTime = InputRuntime.s_Instance.currentTime;
+            m_calibrationDuration = duration;
+            m_accumulatedAccel = Vector3.zero;
+            m_accumulatedGyro = Vector3.zero;
+            m_sampleCount = 0;
+            CalibrationProgress = 0f;
+        }
+
+        /// <summary>
+        /// Calibrates the IMU by setting the current raw sensor values as the new base/offset.
+        /// The controller should be on a flat, stable surface when this is called.
+        /// This will write to the user calibration data section in the controller's SPI flash.
+        /// </summary>
+        private unsafe void WriteUserIMUCalibrationData(Vector3 averageAccel, Vector3 averageGyro)
+        {
+            Debug.Log($"Calibration finished. Average Accel: {averageAccel}, Average Gyro: {averageGyro}. Writing to controller...");
+
+            // Create a 26-byte (0x1A) payload for user calibration data.
+            byte[] payload = new byte[0x1A];
+
+            // Magic number `0xB2 0xA1` at the start.
+            payload[0] = 0xB2;
+            payload[1] = 0xA1;
+
+            // Create a new calibration structure.
+            // The new 'base' is the averaged raw sensor value.
+            // For the accelerometer, we calculate the offset by removing the gravity component from the reading.
+            // 1. Normalize the average acceleration vector to get the direction of gravity.
+            Vector3 gravityDirection = new Vector3(averageAccel.x, averageAccel.y, averageAccel.z).normalized;
+            // 2. 1G corresponds to a raw value of ~4096 (since 4G is ~16384).
+            const float oneGAsRaw = 16384f / 4f;
+            // 3. Calculate the ideal gravity vector in the current orientation.
+            Vector3 idealGravityVector = gravityDirection * oneGAsRaw;
+            // 4. The offset is the measured value minus the ideal gravity vector.
+            Vector3 accelOffset = averageAccel - idealGravityVector;
+
+            // For the gyroscope, we zero out all axes as it should be perfectly still.
+            IMUCalibrationData newUserCalib = new IMUCalibrationData
+            {
+                accelBase = new Vector3UInt16 { x = (ushort)accelOffset.x, y = (ushort)accelOffset.y, z = (ushort)accelOffset.z },
+                // keep factory coefficients unchanged
+                accelSensitivity = calibrationData.imuCalibData.accelSensitivity,
+
+                gyroBase = new Vector3UInt16 { x = (ushort)averageGyro.x, y = (ushort)averageGyro.y, z = (ushort)averageGyro.z },
+                gyroSensitivity = calibrationData.imuCalibData.gyroSensitivity,
+                // keep factory coefficients unchanged
+            };
+
+            // Manually copy the relevant fields (Base and Sensitivity) to the payload to avoid overflow
+            // and to match the 24-byte structure expected by the controller's SPI flash.
+            // The coefficients are not stored on the device.
+            fixed (byte* p = &payload[2])
+            {
+                ushort* ushortPtr = (ushort*)p;
+                ushortPtr[0] = newUserCalib.accelBase.x;
+                ushortPtr[1] = newUserCalib.accelBase.y;
+                ushortPtr[2] = newUserCalib.accelBase.z;
+                ushortPtr[3] = newUserCalib.accelSensitivity.x;
+                ushortPtr[4] = newUserCalib.accelSensitivity.y;
+                ushortPtr[5] = newUserCalib.accelSensitivity.z;
+                ushortPtr[6] = newUserCalib.gyroBase.x;
+                ushortPtr[7] = newUserCalib.gyroBase.y;
+                ushortPtr[8] = newUserCalib.gyroBase.z;
+                ushortPtr[9] = newUserCalib.gyroSensitivity.x;
+                ushortPtr[10] = newUserCalib.gyroSensitivity.y;
+                ushortPtr[11] = newUserCalib.gyroSensitivity.z;
+            }
+
+            Debug.LogWarning("Writing current IMU calibration data to User SPI section. This is permanent!");
+
+            var writeSubcommand = new SwitchControllerWriteSPIFlashSubcommand(
+                atAddress: (uint)SPIFlashReadAddressEnum.UserIMUCalibration,
+                data: payload
+            );
+            var c = SwitchControllerCommand.Create(subcommand: writeSubcommand);
+            if (ExecuteCommand(ref c) < 0)
+                Debug.LogError("Write User IMU calibration info failed");
+
+            CurrentCalibrationState = CalibrationState.Done;
+            CalibrationProgress = 1f;
+        }
+
+        /// <summary>
+        /// Resets the Yaw component of the orientation to zero, using the current direction as the new forward.
+        /// </summary>
+        public void ResetYaw()
+        {
+            // Get the current orientation as a quaternion
+            var currentOrientationQuat = new Quaternion(q1, q2, q3, q0);
+
+            // Get the current yaw angle
+            float currentYaw = currentOrientationQuat.eulerAngles.z;
+
+            // Create a quaternion that represents the inverse of the current yaw rotation
+            var yawCorrection = Quaternion.AngleAxis(-currentYaw, Vector3.forward);
+
+            // Apply the correction to the current orientation
+            var correctedQuat = yawCorrection * currentOrientationQuat;
+
+            // Update the Madgwick quaternion state
+            q0 = correctedQuat.w;
+            q1 = correctedQuat.x;
+            q2 = correctedQuat.y;
+            q3 = correctedQuat.z;
+
+            Debug.Log("Yaw has been reset.");
         }
         #endregion
 
@@ -465,17 +641,7 @@ namespace UnityEngine.InputSystem.Switch
                 Debug.Log("PreProcessEvent: Subcommand report mode");
                 var data = ((SwitchControllerSubcommandResponseInputReport*)stateEvent->state);
                 HandleSubcommand(*data);
-
-                // This appears to fix the bug where the input was flickering
-                // while receiving subcommand replies, but I'm not 100% sure
-                // how it fixes it, since the response should follow a different
-                // format I think??
-                // ...or maybe not, looks like the data should come in the same
-                // packet, according to this:
-                // https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/bluetooth_hid_notes.md#standard-input-report-format
-                HandleFullReport(stateEvent);
-                
-                return true;
+              return false;
             }
 
             // Full report mode!
@@ -490,7 +656,7 @@ namespace UnityEngine.InputSystem.Switch
                 Debug.Log("NFC or infra-red report");
                 return false;
             }
-            else 
+            else
             {
                 Debug.Log($"Unknown report ID: {genericReport->reportId:X2}");
             }
@@ -499,11 +665,34 @@ namespace UnityEngine.InputSystem.Switch
 
         private unsafe void HandleFullReport(StateEvent* stateEvent)
         {
-                SwitchControllerFullInputReport* fullInputReport = ((SwitchControllerFullInputReport*)stateEvent->state);
-                var data = fullInputReport->ToHIDInputReport(ref calibrationData, SpecificControllerType, m_currentOrientation);
-                *((SwitchControllerVirtualInputState*)stateEvent->state) = data;
-                stateEvent->stateFormat = SwitchControllerVirtualInputState.Format;
-                m_currentOrientation += data.angularVelocity;
+            var currentTime = InputRuntime.s_Instance.currentTime;
+            var deltaTime = (float)(currentTime - m_lastUpdateTime);
+            // In editor mode (not playing), deltaTime can be close to zero, which stalls the orientation calculation.
+            // We'll use a fixed delta time based on the controller's report frequency (approx. 60Hz -> 15ms) as a fallback.
+            if (deltaTime < 0.001f)
+            {
+                deltaTime = 0.015f;
+            }
+            m_lastUpdateTime = currentTime;
+
+            SwitchControllerFullInputReport* fullInputReport = ((SwitchControllerFullInputReport*)stateEvent->state);
+            m_lastIMUData = fullInputReport->imuData0ms; // Store the latest raw IMU data
+            var hidInputReport = fullInputReport->ToHIDInputReport(ref calibrationData, SpecificControllerType);
+
+            // Sensor fusion using Madgwick's algorithm
+            if (m_IMUConfigDataLoaded)
+            {
+                // Madgwick's algorithm expects gyroscope data in radians per second.
+                float gx = hidInputReport.angularVelocity.x * Mathf.Deg2Rad;
+                float gy = hidInputReport.angularVelocity.y * Mathf.Deg2Rad;
+                float gz = hidInputReport.angularVelocity.z * Mathf.Deg2Rad;
+
+                MadgwickAHRSUpdate(gx, gy, gz, hidInputReport.acceleration.x, hidInputReport.acceleration.y, hidInputReport.acceleration.z, deltaTime);
+            }
+            hidInputReport.deviceRotation = new Quaternion(q1, q2, q3, q0);
+            hidInputReport.orientation = hidInputReport.deviceRotation.eulerAngles;
+            *((SwitchControllerVirtualInputState*)stateEvent->state) = hidInputReport;
+            stateEvent->stateFormat = SwitchControllerVirtualInputState.Format;
         }
 
         private unsafe void HandleSubcommand(SwitchControllerSubcommandResponseInputReport response)
@@ -611,13 +800,15 @@ namespace UnityEngine.InputSystem.Switch
             {
                 Debug.Log("Read serial number...");
                 DecodeSerialNumberData(response);
-            } 
+                m_serialNumberLoaded = true;
+            }
 
             // IMU factory calibration
             else if (address == (uint)SPIFlashReadAddressEnum.FactoryIMUCalibration && length == 0x18)
             {
                 Debug.Log($"Read factory IMU calibration data...");
                 DecodeIMUCalibrationData((ushort*)response);
+                m_imuCalibrationDataLoaded = true;
             }
 
             // Factory analog stick calibration
@@ -645,7 +836,7 @@ namespace UnityEngine.InputSystem.Switch
             {
                 Debug.Log("Read stick device params 2 data... (not implemented)");
             }
-                
+
             // User analog stick calibration
             else if (address == (uint)SPIFlashReadAddressEnum.UserStickCalibration && length == 0x16)
             {
@@ -656,14 +847,26 @@ namespace UnityEngine.InputSystem.Switch
             else if (address == (uint)SPIFlashReadAddressEnum.UserIMUCalibration && length == 0x1A)
             {
                 Debug.Log($"Read user IMU calibration data...");
-                DecodeIMUCalibrationData((ushort*)response);
+                // The user calibration data has a 2-byte magic number at the start.
+                // We need to skip it before decoding.
+                // The magic number is 0xB2 0xA1.
+                if (response[0] == 0xB2 && response[1] == 0xA1)
+                {
+                    DecodeIMUCalibrationData((ushort*)(response + 2)); // Skip the 2-byte magic number
+                }
+                else
+                {
+                    Debug.LogWarning("User IMU calibration data does not contain the expected magic number. don't decode.");
+                    // DecodeIMUCalibrationData((ushort*)response);
+                }
+                m_imuCalibrationDataLoaded = true;
             }
 
             else
             {
-                Debug.Log($"Unrecognized range: 0x{address:X4}-0x{address+length:X2} (length is {length:X2})");
+                Debug.Log($"Unrecognized range: 0x{address:X4}-0x{address + length:X2} (length is {length:X2})");
             }
-                
+
         }
         #endregion
         #region Data decoding (byte to text/)
@@ -691,20 +894,6 @@ namespace UnityEngine.InputSystem.Switch
             {
                 return $"({x}, {y}, {z})";
             }
-
-            public unsafe Vector3Int16 ToVector3Int16()
-            {
-                var output = new Vector3Int16();
-
-                fixed (void* ptr = &this)
-                {
-                    UnsafeUtility.MemCpy(&output, ptr, 6);
-                }
-
-                // Debug.Log($"{this} -> {output}");
-
-                return output;
-            }
         }
 
         public struct IMUCalibrationData
@@ -714,6 +903,9 @@ namespace UnityEngine.InputSystem.Switch
 
             public Vector3UInt16 gyroBase;
             public Vector3UInt16 gyroSensitivity;
+            
+            public Vector3 accelCoeff;
+            public Vector3 gyroCoeff;
 
             public unsafe static IMUCalibrationData FromResponse(ushort* response)
             {
@@ -748,7 +940,7 @@ namespace UnityEngine.InputSystem.Switch
                     }
                 };
             }
-        
+
             public override string ToString()
             {
                 return $"accelBase = {accelBase}\naccelSen = {accelSensitivity}\ngyroBase = {gyroBase}\ngyroSen = {gyroSensitivity}";
@@ -760,38 +952,127 @@ namespace UnityEngine.InputSystem.Switch
             StringBuilder snStringBuilder = new StringBuilder(15);
 
             Debug.Log($"First byte is {(*response):X2}");
-            if ((*response)>=0X80)
+            if ((*response) >= 0X80)
             {
                 Debug.LogWarning("No valid serial number retrieved");
                 return;
             }
 
-            for (int i=0; i<16; i++)
+            for (int i = 0; i < 16; i++)
             {
-                byte* serialDigit = response+i;
+                byte* serialDigit = response + i;
                 if (*serialDigit == 0x00)
                     continue;
-                
+
                 snStringBuilder.Append(Encoding.ASCII.GetString(serialDigit, 1));
             }
 
             SerialNumber = snStringBuilder.ToString();
-            m_serialNumberLoaded = true;  
+            m_serialNumberLoaded = true; // for prevent read serial infinity loop 
         }
 
         private unsafe void DecodeIMUCalibrationData(ushort* response)
         {
-            calibrationData.imuCalibData = IMUCalibrationData.FromResponse(response);
+            var newCalibData = IMUCalibrationData.FromResponse(response);
+
+            // Pre-calculate the coefficients once when calibration data is loaded.
+            // This avoids redundant calculations in every input report.
+            newCalibData.accelCoeff.x = 4.0f / ((short)newCalibData.accelSensitivity.x - (short)newCalibData.accelBase.x);
+            newCalibData.accelCoeff.y = 4.0f / ((short)newCalibData.accelSensitivity.y - (short)newCalibData.accelBase.y);
+            newCalibData.accelCoeff.z = 4.0f / ((short)newCalibData.accelSensitivity.z - (short)newCalibData.accelBase.z);
+
+            newCalibData.gyroCoeff.x = 936.0f / ((short)newCalibData.gyroSensitivity.x - (short)newCalibData.gyroBase.x);
+            newCalibData.gyroCoeff.y = 936.0f / ((short)newCalibData.gyroSensitivity.y - (short)newCalibData.gyroBase.y);
+            newCalibData.gyroCoeff.z = 936.0f / ((short)newCalibData.gyroSensitivity.z - (short)newCalibData.gyroBase.z);
+
+            calibrationData.imuCalibData = newCalibData;
+
             Debug.Log("Calibration data: " + calibrationData.imuCalibData);
         }
+
+        #region Madgwick Algorithm
+        /// <summary>
+        /// Madgwick's IMU implementation. See: http://www.x-io.co.uk/open-source-imu-and-ahrs-algorithms/
+        /// </summary>
+        private void MadgwickAHRSUpdate(float gx, float gy, float gz, float ax, float ay, float az, float samplePeriod)
+        {
+            float recipNorm;
+            float s0, s1, s2, s3;
+            float qDot1, qDot2, qDot3, qDot4;
+            float _2q0, _2q1, _2q2, _2q3, _4q0, _4q1, _4q2, _8q1, _8q2, q0q0, q1q1, q2q2, q3q3;
+
+            // Rate of change of quaternion from gyroscope
+            qDot1 = 0.5f * (-q1 * gx - q2 * gy - q3 * gz);
+            qDot2 = 0.5f * (q0 * gx + q2 * gz - q3 * gy);
+            qDot3 = 0.5f * (q0 * gy - q1 * gz + q3 * gx);
+            qDot4 = 0.5f * (q0 * gz + q1 * gy - q2 * gx);
+
+            // Compute feedback only if accelerometer measurement valid (avoids NaN in accelerometer normalisation)
+            if (!((ax == 0.0f) && (ay == 0.0f) && (az == 0.0f)))
+            {
+                // Normalise accelerometer measurement
+                recipNorm = 1.0f / Mathf.Sqrt(ax * ax + ay * ay + az * az);
+                ax *= recipNorm;
+                ay *= recipNorm;
+                az *= recipNorm;
+
+                // Auxiliary variables to avoid repeated arithmetic
+                _2q0 = 2.0f * q0;
+                _2q1 = 2.0f * q1;
+                _2q2 = 2.0f * q2;
+                _2q3 = 2.0f * q3;
+                _4q0 = 4.0f * q0;
+                _4q1 = 4.0f * q1;
+                _4q2 = 4.0f * q2;
+                _8q1 = 8.0f * q1;
+                _8q2 = 8.0f * q2;
+                q0q0 = q0 * q0;
+                q1q1 = q1 * q1;
+                q2q2 = q2 * q2;
+                q3q3 = q3 * q3;
+
+                // Gradient decent algorithm corrective step
+                s0 = _4q0 * q2q2 + _2q2 * ax + _4q0 * q1q1 - _2q1 * ay;
+                s1 = _4q1 * q3q3 - _2q3 * ax + 4.0f * q0q0 * q1 - _2q0 * ay - _4q1 + _8q1 * q1q1 + _8q1 * q2q2 + _4q1 * az;
+                s2 = 4.0f * q0q0 * q2 + _2q0 * ax + _4q2 * q3q3 - _2q3 * ay - _4q2 + _8q2 * q1q1 + _8q2 * q2q2 + _4q2 * az;
+                s3 = 4.0f * q1q1 * q3 - _2q1 * ax + 4.0f * q2q2 * q3 - _2q2 * ay;
+                recipNorm = 1.0f / Mathf.Sqrt(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+                s0 *= recipNorm;
+                s1 *= recipNorm;
+                s2 *= recipNorm;
+                s3 *= recipNorm;
+
+                // Apply feedback step
+                qDot1 -= MadgwickBeta * s0;
+                qDot2 -= MadgwickBeta * s1;
+                qDot3 -= MadgwickBeta * s2;
+                qDot4 -= MadgwickBeta * s3;
+            }
+
+            // Integrate rate of change of quaternion to yield quaternion
+            q0 += qDot1 * samplePeriod;
+            q1 += qDot2 * samplePeriod;
+            q2 += qDot3 * samplePeriod;
+            q3 += qDot4 * samplePeriod;
+
+            // Normalise quaternion
+            recipNorm = 1.0f / Mathf.Sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+            q0 *= recipNorm;
+            q1 *= recipNorm;
+            q2 *= recipNorm;
+            q3 *= recipNorm;
+        }
+
+
+        #endregion
 
         private unsafe void DecodeStickCalibrationData(byte* response)
         {
             DecodeLeftStickData(response);
-            DecodeRightStickData(response + 9);  
+            DecodeRightStickData(response + 9);
 
-            Debug.Log($"Calibration data loaded");   
-            m_stickConfigDataLoaded = true;  
+            Debug.Log($"Calibration data loaded");
+            m_stickConfigDataLoaded = true;
         }
 
         private unsafe void DecodeColorData(byte* response)

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
@@ -901,7 +901,7 @@ namespace UnityEngine.InputSystem.Switch
                 return new StickCalibrationData() { xMin = 0, xMax = 0, yMin = 0, yMax = 0, xCenter = 0, yCenter = 0 };
             }
 
-            public override readonly string ToString()
+            public override string ToString()
             {
                 return String.Format($"Center: ({xCenter:X2};{yCenter:X2}), X range: [{xMin:X2}-{xMax:X2}], Y range: [{yMin:X2}-{yMax:X2}]");
             }

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerInputState.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerInputState.cs
@@ -8,7 +8,7 @@ using UnityEngine.InputSystem.Utilities;
 // as a base here
 namespace UnityEngine.InputSystem.Switch.LowLevel
 {
-    #if UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_WSA
+#if UNITY_EDITOR || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_WSA
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct SwitchControllerVirtualInputState : IInputStateTypeInfo
     {
@@ -67,6 +67,16 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [InputControl(name = "orientation", layout = "Vector3", format = "VEC3", noisy = true)]
         public Vector3 orientation;
 
+        [InputControl(name = "deviceRotation", layout = "Quaternion", format = "QUAT", noisy = true, displayName = "Device Rotation")]
+        public Quaternion deviceRotation;
+
+        // These are exposed as controls for debugging purposes.
+        [InputControl(name = "uncalibratedAcceleration", layout = "Vector3", format = "VEC3", noisy = true, displayName = "Uncalibrated Acceleration")]
+        public Vector3 uncalibratedAcceleration;
+
+        [InputControl(name = "uncalibratedAngularVelocity", layout = "Vector3", format = "VEC3", noisy = true, displayName = "Uncalibrated Angular Velocity")]
+        public Vector3 uncalibratedAngularVelocity;
+
         public enum Button
         {
             Up = 0,
@@ -108,5 +118,5 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
                 buttons &= (uint)~bit;
         }
     }
-    #endif
+#endif
 }

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchSpecificControllersHID.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchSpecificControllersHID.cs
@@ -101,7 +101,8 @@ namespace UnityEngine.InputSystem.Switch
             var matcher = new InputDeviceMatcher()
                 .WithInterface("HID")
                 .WithCapability("vendorId", 0x57E)
-                .WithCapability("productId", 0x2009);
+                .WithCapability("productId", 0x2009)
+                .WithProduct("Wireless Gamepad");
             
             InputSystem.RegisterLayout<SwitchProControllerNewHID>(matches: matcher);
             


### PR DESCRIPTION
Closes #3 
This issue occurred because the Unity InputSystem already has a layout for SwitchProControllerHID, and the matcher used for SwitchProControllerNewHID was identical, causing its layout registration to be ignored. To resolve this, we applied a more specific match condition to give priority to SwitchProControllerNewHID.